### PR TITLE
6.x 3.x

### DIFF
--- a/modules/taxonomy/views_handler_argument_term_node_tid.inc
+++ b/modules/taxonomy/views_handler_argument_term_node_tid.inc
@@ -40,7 +40,7 @@ class views_handler_argument_term_node_tid extends views_handler_argument_many_t
     $titles = array();
     $placeholders = implode(', ', array_fill(0, sizeof($this->value), '%d'));
 
-    $result = db_query(db_rewrite_sql("SELECT name FROM {term_data} td WHERE td.tid IN ($placeholders)", 'td', 'tid', array($this->value)), $this->value);
+    $result = db_query(db_rewrite_sql("SELECT td.name FROM {term_data} td WHERE td.tid IN ($placeholders)", 'td', 'tid', array($this->value)), $this->value);
     while ($term = db_fetch_object($result)) {
       $titles[] = check_plain($term->name);
     }

--- a/modules/taxonomy/views_handler_filter_term_node_tid.inc
+++ b/modules/taxonomy/views_handler_filter_term_node_tid.inc
@@ -274,7 +274,7 @@ class views_handler_filter_term_node_tid extends views_handler_filter_many_to_on
     // add the taxonomy vid to the argument list.
     $args[] = $this->options['vid'];
 
-    $result = db_query(db_rewrite_sql("SELECT * FROM {term_data} td WHERE td.name IN (" . implode(', ', $placeholders) . ") AND td.vid = %d", 'td', 'tid', $args), $args);
+    $result = db_query(db_rewrite_sql("SELECT td.* FROM {term_data} td WHERE td.name IN (" . implode(', ', $placeholders) . ") AND td.vid = %d", 'td', 'tid', $args), $args);
     while ($term = db_fetch_object($result)) {
       unset($missing[strtolower($term->name)]);
       $tids[] = $term->tid;

--- a/modules/taxonomy/views_plugin_argument_validate_taxonomy_term.inc
+++ b/modules/taxonomy/views_plugin_argument_validate_taxonomy_term.inc
@@ -76,7 +76,7 @@ class views_plugin_argument_validate_taxonomy_term extends views_plugin_argument
           return FALSE;
         }
 
-        $result = db_fetch_object(db_query(db_rewrite_sql("SELECT * FROM {term_data} td WHERE td.tid = %d", 'td', 'tid', array($argument)),  $argument));
+        $result = db_fetch_object(db_query(db_rewrite_sql("SELECT td.* FROM {term_data} td WHERE td.tid = %d", 'td', 'tid', array($argument)),  $argument));
         if (!$result) {
           return FALSE;
         }
@@ -119,7 +119,7 @@ class views_plugin_argument_validate_taxonomy_term extends views_plugin_argument
         if (count($test)) {
           $placeholders = implode(', ', array_fill(0, count($test), '%d'));
 
-          $result = db_query(db_rewrite_sql("SELECT * FROM {term_data} td WHERE td.tid IN ($placeholders)", 'td', 'tid', array($test)), $test);
+          $result = db_query(db_rewrite_sql("SELECT td.* FROM {term_data} td WHERE td.tid IN ($placeholders)", 'td', 'tid', array($test)), $test);
           while ($term = db_fetch_object($result)) {
             if ($vids && empty($vids[$term->vid])) {
               $validated_cache[$term->tid] = FALSE;


### PR DESCRIPTION
The last commit for a security issue breaks views with taxonomy filters or arguments on sites that use node access modules such as forum_access. They may add duplicate column names to the queries via db_rewrite_sql because the original query is not prefixing selected columns with a table prefix.