### PR TITLE
Backport fix - Issue #662692 strange decimal precision error on floating numeric fields.

### DIFF
--- a/handlers/views_handler_field_numeric.inc
+++ b/handlers/views_handler_field_numeric.inc
@@ -101,12 +101,13 @@ class views_handler_field_numeric extends views_handler_field {
       $value = number_format($value, $this->options['precision'], $this->options['decimal'], $this->options['separator']);
     }
     else {
-      $remainder = abs($value) - intval(abs($value));
+      $point_position = strpos($value, '.');
+      $remainder = ($point_position === FALSE) ? '' : substr($value, $point_position + 1);
       $value = $value > 0 ? floor($value) : ceil($value);
       $value = number_format($value, 0, '', $this->options['separator']);
       if ($remainder) {
         // The substr may not be locale safe.
-        $value .= $this->options['decimal'] . substr($remainder, 2);
+        $value .= $this->options['decimal'] . $remainder;
       }
     }
 


### PR DESCRIPTION
[Issue #662692](https://www.drupal.org/project/views/issues/662692) by joachim, hanoii, ShaneOnABike, lunazoid, 5t4rdu5t: strange decimal precision error on floating numeric fields.

Cherry-picked: https://git.drupalcode.org/project/views/commit/8d86ce2


Essentially in views_handler_field_numeric, if you don't set precision you can get weird floating point issues.